### PR TITLE
feature complete: improve status output #9

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -71,7 +71,7 @@ func pretty(filename string) string {
 
 	fn := strings.Replace(strings.TrimSuffix(filename, filepath.Ext(filename)), "_", " ", -1)
 
-	if len(fn) < 15 {
+	if len(fn) < 16 {
 		return fmt.Sprintf("%s (%s)", fn, filename)
 	}
 
@@ -81,7 +81,7 @@ func pretty(filename string) string {
 		return fmt.Sprintf("%s (%s)", fn, filename)
 	}
 
-	fn = strings.Replace(strings.TrimPrefix(fn, fn[0:16]), "", "", -1)
+	fn = fn[16:]
 
 	return fmt.Sprintf("%s-%s-%s %s:%s:%s %s (%s)",
 		filename[0:4],

--- a/utils.go
+++ b/utils.go
@@ -66,16 +66,21 @@ func promptForYes(message string) bool {
 }
 
 // 20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml
-// 2018-02-27 14:06:00 permit infra_manager to deploy to gateway cluster
+// 2018-02-27 14:06:00 permit infra manager to deploy to gateway cluster (20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)
 func pretty(filename string) string {
-	return fmt.Sprintf("%s-%s-%s %s:%s:%s %s",
+
+	// remove date prefix and file extension postfix
+	fn := strings.Replace(strings.TrimPrefix(filename, filename[0:16]), "_", " ", -1)
+	fn = strings.Replace(strings.TrimSuffix(fn, filepath.Ext(fn)), "", "", -1)
+
+	return fmt.Sprintf("%s-%s-%s %s:%s:%s %s (%s)",
 		filename[0:4],
 		filename[4:6],
 		filename[6:8],
 		filename[9:11],
 		filename[11:13],
 		filename[13:15],
-		strings.Replace(strings.TrimSuffix(filename, filepath.Ext(filename)), "_", " ", -1))
+		fn, filename)
 }
 
 func isYamlFile(filename string) bool {

--- a/utils.go
+++ b/utils.go
@@ -81,8 +81,6 @@ func pretty(filename string) string {
 		return fmt.Sprintf("%s (%s)", fn, filename)
 	}
 
-	fn = fn[16:]
-
 	return fmt.Sprintf("%s-%s-%s %s:%s:%s %s (%s)",
 		filename[0:4],
 		filename[4:6],
@@ -90,7 +88,7 @@ func pretty(filename string) string {
 		filename[9:11],
 		filename[11:13],
 		filename[13:15],
-		fn, filename)
+		fn[16:], filename)
 }
 
 func isYamlFile(filename string) bool {

--- a/utils.go
+++ b/utils.go
@@ -69,9 +69,19 @@ func promptForYes(message string) bool {
 // 2018-02-27 14:06:00 permit infra manager to deploy to gateway cluster (20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)
 func pretty(filename string) string {
 
-	// remove date prefix and file extension postfix
-	fn := strings.Replace(strings.TrimPrefix(filename, filename[0:16]), "_", " ", -1)
-	fn = strings.Replace(strings.TrimSuffix(fn, filepath.Ext(fn)), "", "", -1)
+	fn := strings.Replace(strings.TrimSuffix(filename, filepath.Ext(filename)), "_", " ", -1)
+
+	if len(fn) < 15 {
+		return fmt.Sprintf("%s (%s)", fn, filename)
+	}
+
+	// 20060102t150405 is used as a sample format, see https://golang.org/pkg/time/#Parse
+	_, err := time.Parse("20060102t150405", fn[0:15])
+	if err != nil {
+		return fmt.Sprintf("%s (%s)", fn, filename)
+	}
+
+	fn = strings.Replace(strings.TrimPrefix(fn, fn[0:16]), "", "", -1)
 
 	return fmt.Sprintf("%s-%s-%s %s:%s:%s %s (%s)",
 		filename[0:4],

--- a/utils_test.go
+++ b/utils_test.go
@@ -15,11 +15,24 @@ func (c *commandCapturer) runCommand(cmd *exec.Cmd) ([]byte, error) {
 	return c.output, nil
 }
 
-func TestPrettyPrint(t *testing.T) {
-	testStr := "20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml"
-	expected := "2018-02-27 14:06:00 permit infra manager to deploy to gateway cluster (20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"
+var dateTests = []struct {
+	in  string
+	out string
+}{
+	{"20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml", "2018-02-27 14:06:00 permit infra manager to deploy to gateway cluster (20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"},
+	{"20161230t235959_permit_infra_manager_to_deploy_to_gateway_cluster.yaml", "2016-12-30 23:59:59 permit infra manager to deploy to gateway cluster (20161230t235959_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"},
+	{"20170604t031224_permit_infra_manager_to_deploy_to_gateway_cluster.yaml", "2017-06-04 03:12:24 permit infra manager to deploy to gateway cluster (20170604t031224_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"},
+	{"20180101t000000_permit_infra_manager_to_deploy_to_gateway_cluster.yaml", "2018-01-01 00:00:00 permit infra manager to deploy to gateway cluster (20180101t000000_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"},
+	{"20011122t090620_permit_infra_manager_to_deploy_to_gateway_cluster.yaml", "2001-11-22 09:06:20 permit infra manager to deploy to gateway cluster (20011122t090620_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"},
+	{"permit_infra_manager_to_deploy_to_gateway_cluster.yaml", "permit infra manager to deploy to gateway cluster (permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"},
+	{"permit.yaml", "permit (permit.yaml)"},
+}
 
-	if got, want := pretty(testStr), expected; got != want {
-		t.Errorf("got [%v] want [%v]", got, want)
+func TestPrettyPrint(t *testing.T) {
+	for _, tt := range dateTests {
+		actual := pretty(tt.in)
+		if actual != tt.out {
+			t.Errorf("pretty(%v): expected %v, actual %v", tt.in, tt.out, actual)
+		}
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "os/exec"
+import (
+	"os/exec"
+	"testing"
+)
 
 type commandCapturer struct {
 	args   [][]string
@@ -10,4 +13,13 @@ type commandCapturer struct {
 func (c *commandCapturer) runCommand(cmd *exec.Cmd) ([]byte, error) {
 	c.args = append(c.args, cmd.Args)
 	return c.output, nil
+}
+
+func TestPrettyPrint(t *testing.T) {
+	testStr := "20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml"
+	expected := "2018-02-27 14:06:00 permit infra manager to deploy to gateway cluster (20180227t140600_permit_infra_manager_to_deploy_to_gateway_cluster.yaml)"
+
+	if got, want := pretty(testStr), expected; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
 }


### PR DESCRIPTION
Modified the pretty method according to the suggestion in the comments on issue #9.
Added simple unit test just to make sure it parses the correct way.

tbd: What will happen if a user creates his own migration file (not using gmig) in an incorrect format, e.g. without date.. provided that the string is at least 15 characters long, it will probably not fail, just give a weird (but expected) result given current implementation of splitting the date, if it does provide a string with <= 15 characters, will it fail? Do we need to write tests for this and accommodate these scenarios?