### PR TITLE
Standardized CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you want to create your own version, you need to compile it using the [Go SDK
 
     go get github.com/emicklei/gmig
 
-### init [path]
+### init \<path>
 
 Prepares your setup for working with migrations by creating a `gmig.json` file in a target folder.
 
@@ -118,7 +118,7 @@ You must change the file `gmig.json` to set the Bucket name.
 If you decide to store state files of different projects in one Bucket then set the state object name to reflect this, eg. `myproject-gmig-state`.
 If you want to apply the same migrations to different regions/zones then choose a target folder name to reflect this, eg. `my-gcp-production-project-us-east`. Values for `region` and `zone` are required if you want to create Compute Engine resources. The `env` map can be used to parameterize commands in your migrations. All commands will have access to the value of `$FOO`.
 
-### new [title]
+### new \<title>
 
 Creates a new migration for you to describe a change to the current state of infrastructure.
 
@@ -126,7 +126,7 @@ Creates a new migration for you to describe a change to the current state of inf
 
 Using a combination of the options `--do`, `--undo` and `--view`, you can set the commands directly for the new migration.
 
-### status [path] [--migrations folder]
+### status \<path> [--migrations folder]
 
 List all migrations with an indicator (applied,pending) whether is has been applied or not.
 
@@ -134,12 +134,12 @@ List all migrations with an indicator (applied,pending) whether is has been appl
 
 Run this command in the directory where all migrations are stored. Use `--migrations` for a different location.
 
-### plan  [path] [|migration file] [--migrations folder]
+### plan \<path> [migration file] [--migrations folder]
 
 Log commands of the `do` section of all pending migrations in order, one after the other.
 If `migration file` is given then stop after applying that one.
 
-### up [path] [|migration file] [--migrations folder]
+### up \<path> [migration file] [--migrations folder]
 
 Executes the `do` section of each pending migration compared to the last applied change to the infrastructure.
 If `migration file` is given then stop after applying that one.
@@ -147,14 +147,14 @@ Upon each completed migration, the `gmig-last-migration` object is updated in th
 
     gmig up my-gcp-production-project
 
-### down [path] [--migrations folder]
+### down \<path> [--migrations folder]
 
 Executes one `undo` section of the last applied change to the infrastructure.
 If completed then update the `gmig-last-migration` object.
 
     gmig down my-gcp-production-project
 
-### view [path] [|migration file]  [--migrations folder]
+### view \<path> [migration file] [--migrations folder]
 
 Executes the `view` section of each applied migration to the infrastructure.
 If `migration file` is given then run that view only.
@@ -168,13 +168,13 @@ Several sub commands are (or will become) available to inspect a project and exp
 After marking the current state in `gmig` (using `force-state`), new migrations can be added that will bring your infrastructure to the next state.
 The generated migration can ofcourse also be used to just copy commands to your own migration.
 
-### export project-iam-policy [path]
+### export project-iam-policy \<path>
 
 Generate a new migration by reading all the IAM policy bindings from the current infrastructure of the project.
 
     gmig -v export project-iam-policy my-project/
 
-### export storage-iam-policy [path]
+### export storage-iam-policy \<path>
 
 Generate a new migration by reading all the IAM policy bindings, per Google Storage Bucket owned by the project.
 
@@ -184,14 +184,14 @@ Generate a new migration by reading all the IAM policy bindings, per Google Stor
 
 Sometimes you need to fix things because you made a mistake or want to reorganise your work. Use the `force` and confirm your action.
 
-### force state [path] [filename]
+### force state \<path> \<filename>
 
 Explicitly set the state for the target to the last applied filename. This command can be useful if you need to work from existing infrastructure. Effectively, this filename is written to the bucket object.
 Use this command with care!.
 
     gmig force state my-gcp-production-project 20180214t071402_create_some_account.yaml
 
-### force do [path] [filename]
+### force do \<path> \<filename>
 
 Explicitly run the commands in the `do` section of a given migration filename.
 The `gmig-last-migration` object is `not` updated in the bucket.
@@ -199,7 +199,7 @@ Use this command with care!.
 
     gmig force do my-gcp-production-project 20180214t071402_create_some_account.yaml
 
-### force undo [path] [filename]
+### force undo \<path> \<filename>
 
 Explicitly run the commands in the `undo` section of a given migration filename.
 The `gmig-last-migration` object is `not` updated in the bucket.
@@ -209,12 +209,12 @@ Use this command with care!.
 
 ## GCP utilities
 
-### util create-named-port [instance-group] [name:port]
+### util create-named-port \<instance-group> \<name:port>
 
 The Cloud SDK has a command to [set-named-ports](https://cloud.google.com/sdk/gcloud/reference/compute/instance-groups/set-named-ports) but not a command to add or delete a single name:port mapping. To simplify the migration command for creating a name:port mapping, this gmig util command is added.
 First it calls `get-named-ports` to retrieve all existing mappings. Then it will call `set-named-ports` with the new mapping unless it already exists.
 
-### util delete-named-port [instance-group] [name:port]
+### util delete-named-port \<instance-group> \<name:port>
 
 The Cloud SDK has a command to [set-named-ports](https://cloud.google.com/sdk/gcloud/reference/compute/instance-groups/set-named-ports) but not a command to add or delete a single name:port mapping. To simplify the migration command for deleting a name:port mapping, this gmig util command is added.
 First it calls `get-named-ports` to retrieve all existing mappings. Then it will call `set-named-ports` without the mapping.

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func newApp() *cli.App {
 				defer started(c, "init")()
 				return cmdInit(c)
 			},
-			ArgsUsage: `[path]
+			ArgsUsage: `<path>
 				path - name of the folder that contains the configuration of the target project. The folder name may end with a path separator and can be relative or absolute.`,
 		},
 		{
@@ -76,7 +76,7 @@ func newApp() *cli.App {
 					Usage: "commands to run in the 'view' section of this migration. Multiple commands need to be separated by a newline.",
 				},
 			},
-			ArgsUsage: `[title]
+			ArgsUsage: `<title>
 				title - what the effect of this migration is on infrastructure.`,
 		},
 		{
@@ -87,7 +87,7 @@ func newApp() *cli.App {
 				return cmdMigrationsPlan(c)
 			},
 			Flags: []cli.Flag{migrationsFlag},
-			ArgsUsage: `[path] [stop] 
+			ArgsUsage: `<path> [stop] 
 				path - name of the folder that contains the configuration of the target project.
 				stop - (optional) the name of the migration file after which applying migrations will stop.`,
 		},
@@ -99,19 +99,19 @@ func newApp() *cli.App {
 				return cmdMigrationsUp(c)
 			},
 			Flags: []cli.Flag{migrationsFlag},
-			ArgsUsage: `[path] [stop] 
+			ArgsUsage: `<path> [stop] 
 				path - name of the folder that contains the configuration of the target project.
 				stop - (optional) the name of the migration file after which applying migrations will stop.`,
 		},
 		{
 			Name:  "down",
-			Usage: "Runs the undo section of the last applied migration only.",
+			Usage: "Runs the undo section of only the last applied migration.",
 			Action: func(c *cli.Context) error {
 				defer started(c, "down = undo last applied migration")()
 				return cmdMigrationsDown(c)
 			},
 			Flags: []cli.Flag{migrationsFlag},
-			ArgsUsage: `[path]
+			ArgsUsage: `<path>
 				path - name of the folder that contains the configuration of the target project.`,
 		},
 		{
@@ -122,7 +122,7 @@ func newApp() *cli.App {
 				return cmdMigrationsStatus(c)
 			},
 			Flags: []cli.Flag{migrationsFlag},
-			ArgsUsage: `[path]
+			ArgsUsage: `<path>
 				path - name of the folder that contains the configuration of the target project.`,
 		},
 		{
@@ -133,12 +133,12 @@ func newApp() *cli.App {
 				return cmdView(c)
 			},
 			Flags: []cli.Flag{migrationsFlag},
-			ArgsUsage: `[path]
+			ArgsUsage: `<path>
 				path - name of the folder that contains the configuration of the target project.`,
 		},
 		{
 			Name:  "util",
-			Usage: "create-named-port | delete-named-port",
+			Usage: "{create-named-port|delete-named-port}",
 			Subcommands: []cli.Command{
 				{
 					Name:  "create-named-port",
@@ -147,7 +147,7 @@ func newApp() *cli.App {
 						defer started(c, "create-named-port")()
 						return cmdCreateNamedPort(c)
 					},
-					ArgsUsage: `[instance-group] [name:port]
+					ArgsUsage: `<instance-group> <name:port>
 					instance-group - identifier of the compute instance group
 					name:port      - mapping of a name to a port, e.g  http-port:80`,
 				},
@@ -158,7 +158,7 @@ func newApp() *cli.App {
 						defer started(c, "delete-named-port")()
 						return cmdDeleteNamedPort(c)
 					},
-					ArgsUsage: `[instance-group] [name:port]
+					ArgsUsage: `<instance-group> <name:port>
 					instance-group - identifier of the compute instance group
 					name:port      - mapping of a name to a port, e.g  http-port:80`,
 				},
@@ -166,7 +166,7 @@ func newApp() *cli.App {
 		},
 		{
 			Name:  "force",
-			Usage: "state | do | undo",
+			Usage: "{state|do|undo}",
 			Flags: []cli.Flag{migrationsFlag},
 			Subcommands: []cli.Command{
 				{
@@ -176,7 +176,7 @@ func newApp() *cli.App {
 						defer started(c, "force last applied migration (state)")()
 						return cmdMigrationsSetState(c)
 					},
-					ArgsUsage: `[path]
+					ArgsUsage: `<path>
 					path - name of the folder that contains the configuration of the target project.`,
 				},
 				{
@@ -186,7 +186,7 @@ func newApp() *cli.App {
 						defer started(c, "execute DO section")()
 						return cmdRundoOnly(c)
 					},
-					ArgsUsage: `[path] [filename]
+					ArgsUsage: `<path> <filename>
 						path - name of the folder that contains the configuration of the target project.
 						filename - name of the migration that contains a do: section.`,
 				},
@@ -197,7 +197,7 @@ func newApp() *cli.App {
 						defer started(c, "execute UNDO section")()
 						return cmdRunUndoOnly(c)
 					},
-					ArgsUsage: `[path] [filename]
+					ArgsUsage: `<path> <filename>
 					path - name of the folder that contains the configuration of the target project.
 					filename - name of the migration that contains a undo: section.`,
 				},
@@ -205,7 +205,7 @@ func newApp() *cli.App {
 		},
 		{
 			Name:  "export",
-			Usage: "project-iam-policy | storage-iam-policy",
+			Usage: "{project-iam-policy|storage-iam-policy}",
 			Subcommands: []cli.Command{
 				{
 					Name:  "project-iam-policy",
@@ -214,7 +214,7 @@ func newApp() *cli.App {
 						defer started(c, "export project IAM policy")()
 						return cmdExportProjectIAMPolicy(c)
 					},
-					ArgsUsage: `[path]
+					ArgsUsage: `<path>
 					path - name of the folder that contains the configuration of the target project.`,
 				},
 				{
@@ -224,7 +224,7 @@ func newApp() *cli.App {
 						defer started(c, "export storage IAM policy")()
 						return cmdExportStorageIAMPolicy(c)
 					},
-					ArgsUsage: `[path]
+					ArgsUsage: `<path>
 					path - name of the folder that contains the configuration of the target project.`,
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func newApp() *cli.App {
 		},
 		{
 			Name:  "util",
-			Usage: "{create-named-port|delete-named-port}",
+			Usage: "Handle named ports {create-named-port|delete-named-port}",
 			Subcommands: []cli.Command{
 				{
 					Name:  "create-named-port",
@@ -166,12 +166,12 @@ func newApp() *cli.App {
 		},
 		{
 			Name:  "force",
-			Usage: "{state|do|undo}",
+			Usage: "Force an action {state|do|undo}",
 			Flags: []cli.Flag{migrationsFlag},
 			Subcommands: []cli.Command{
 				{
 					Name:  "state",
-					Usage: "Explicitly set the current state; filename of the last applied migration.",
+					Usage: "Explicitly set the state to a specified migration filename.",
 					Action: func(c *cli.Context) error {
 						defer started(c, "force last applied migration (state)")()
 						return cmdMigrationsSetState(c)
@@ -181,7 +181,7 @@ func newApp() *cli.App {
 				},
 				{
 					Name:  "do",
-					Usage: "Explicitly execute the DO section of a migration. Does not update the state object in the bucket.",
+					Usage: "Force run the DO section of a migration. State will not be updated.",
 					Action: func(c *cli.Context) error {
 						defer started(c, "execute DO section")()
 						return cmdRundoOnly(c)
@@ -192,7 +192,7 @@ func newApp() *cli.App {
 				},
 				{
 					Name:  "undo",
-					Usage: "Explicitly execute the UNDO section of a migration. Does not update the state object in the bucket.",
+					Usage: "Force run the UNDO section of a migration. State will not be updated.",
 					Action: func(c *cli.Context) error {
 						defer started(c, "execute UNDO section")()
 						return cmdRunUndoOnly(c)
@@ -205,7 +205,7 @@ func newApp() *cli.App {
 		},
 		{
 			Name:  "export",
-			Usage: "{project-iam-policy|storage-iam-policy}",
+			Usage: "Export existing infrastructure {project-iam-policy|storage-iam-policy}",
 			Subcommands: []cli.Command{
 				{
 					Name:  "project-iam-policy",


### PR DESCRIPTION
main.go doesn't parse the optional [--migrations folder], even though the documentation refers to it. Is it fine if If delete the usage of that flag?

Also, in the main.go, when dealing with export, there are two arguments: name and usage. When I run 'gmig export -h' then the output is a bit confusing because of the automatically inserted dash.

> NAME:
>   gmig export - {project-iam-policy|storage-iam-policy}

