### PR TITLE
Align cli help and docs: [stop]

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ and use the `view` subcommand.
 
 ## Getting started
 
-### Instalation
+### Installation
 
 Pre-compiled binaries are available for download from the Releases section on this page.
 If you want to create your own version, you need to compile it using the [Go SDK](https://golang.org/dl/).

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ List all migrations with an indicator (applied,pending) whether is has been appl
 
 Run this command in the directory where all migrations are stored. Use `--migrations` for a different location.
 
-### plan \<path> [migration file] [--migrations folder]
+### plan \<path> [stop] [--migrations folder]
 
 Log commands of the `do` section of all pending migrations in order, one after the other.
-If `migration file` is given then stop after applying that one.
+If `stop` is given, then stop after that migration file.
 
-### up \<path> [migration file] [--migrations folder]
+### up \<path> [stop] [--migrations folder]
 
 Executes the `do` section of each pending migration compared to the last applied change to the infrastructure.
-If `migration file` is given then stop after applying that one.
+If `stop` is given, then stop after that migration file.
 Upon each completed migration, the `gmig-last-migration` object is updated in the bucket.
 
     gmig up my-gcp-production-project


### PR DESCRIPTION
The CLI said there is an optional parameter `stop`, but docs talk about an optional `migration file`. I updated the docs so they both talk about `stop` parameter now.