### PR TITLE
Restrict migfation file start to index or timestamp

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -144,7 +144,7 @@ func LoadMigrationsBetweenAnd(migrationsPath, firstFilename, lastFilename string
 	}
 	defer os.Chdir(here)
 	filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() || !isYamlFile(path) {
+		if !isValidMigrationFilename(&path, &info) {
 			return nil
 		}
 		filenames = append(filenames, path)

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -94,4 +95,19 @@ func pretty(filename string) string {
 func isYamlFile(filename string) bool {
 	ext := filepath.Ext(filename)
 	return ext == ".yaml" || ext == ".yml"
+}
+
+var regexpIndex, _ = regexp.Compile("^[0-9]{3}_")
+var regexpTimestamp, _ = regexp.Compile("^[0-9]{8}t[0-9]{6}_")
+
+func isValidMigrationFilename(path *string, info *os.FileInfo) bool {
+	if (*info).IsDir() || !isYamlFile(*path) {
+		return false
+	}
+	hasIndex := regexpIndex.MatchString(*path)
+	hasTimestamp := regexpTimestamp.MatchString(*path)
+	if !hasIndex && !hasTimestamp {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
LoadMigrationsBetweenAnd now lists only those files which pass a test of isValidMigrationFilename, which now includes checking whether it starts with either 3 digit index (followed by an underscore) or a timestamp (followed by an underscore)

Fixes #26  