### PR TITLE
replace timestamp with index

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -33,7 +33,7 @@ func cmdCreateMigration(c *cli.Context) error {
 		printError("missing migration title")
 		return errAbort
 	}
-	filename := NewFilename(desc)
+	filename := NewFilenameWithIndex(desc)
 	defaultCommands := []string{"gcloud config list"}
 	doSection, undoSection, viewSection := defaultCommands, defaultCommands, []string{}
 	if doValue := c.String("do"); len(doValue) > 0 {

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -95,3 +96,6 @@ func isYamlFile(filename string) bool {
 	ext := filepath.Ext(filename)
 	return ext == ".yaml" || ext == ".yml"
 }
+
+var regexpIndex, _ = regexp.Compile("^[0-9]{3}_")
+var regexpTimestamp, _ = regexp.Compile("^[0-9]{8}t[0-9]{6}_")


### PR DESCRIPTION
New migration names now start with an index rather than a timestamp. Tests are included.

`gmig vet migrations` could be a next addition.

Fixes #18 