### PR TITLE
Prevent possible nil pointer for json config

### DIFF
--- a/config.go
+++ b/config.go
@@ -87,7 +87,7 @@ func TryToLoadConfig(pathToConfig string) (*Config, error) {
 		return loadYAMLConfig(ymlLocation)
 	} else if checkExists(jsonLocation) == nil {
 		config, err := loadJSONConfig(jsonLocation)
-		printWarning(fmt.Sprintf("JSON configuration (gmig.json) is deprecated, your configuration (gmig.yaml) in YAML\n========\n%s========\n", config.ToYAML()))
+		printWarning("JSON configuration (gmig.json) is deprecated, your configuration (gmig.yaml)")
 		return config, err
 	}
 


### PR DESCRIPTION
When there is an error in the JSON config it still wanted to print the config. Since the JSON configuration is deprecated I changed it so it doesn't print the configuration. 